### PR TITLE
implemented way to pick one samplerate from the VISXP_PREP dataset

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -32,16 +32,17 @@ VISXP_EXTRACT:
     MODEL_BASE_MOUNT: /model
     MODEL_CHECKPOINT_FILE: checkpoint.tar  # should be in MODEL_BASE_MOUNT
     MODEL_CONFIG_FILE: model_config.yml  # should be in MODEL_BASE_MOUNT
+    EXPECTED_SPECTOGRAM_SAMPLERATE_HZ: 24000  # -1 indicates undefined otherwise: 24000 | 48000
     TEST_INPUT_PATH: /data/input-files/testob/visxp_prep__testob.tar.gz
 INPUT:
-    S3_ENDPOINT_URL: https://s3-host
+    S3_ENDPOINT_URL: https://s3.eu-west-1.amazonaws.com/
     MODEL_CHECKPOINT_S3_URI: s3://beng-daan-visxp/model/checkpoint.tar
     MODEL_CONFIG_S3_URI: s3://beng-daan-visxp/model/model_config.yml
     DELETE_ON_COMPLETION: False
 OUTPUT:
     DELETE_ON_COMPLETION: True
     TRANSFER_ON_COMPLETION: True
-    S3_ENDPOINT_URL: https://s3-host
+    S3_ENDPOINT_URL: https://s3.eu-west-1.amazonaws.com/
     S3_BUCKET: beng-daan-visxp  # bucket reserved for 1 type of output
     S3_FOLDER_IN_BUCKET: assets  # folder within the bucket
 DANE_DEPENDENCIES:

--- a/config/config.yml
+++ b/config/config.yml
@@ -35,14 +35,14 @@ VISXP_EXTRACT:
     EXPECTED_SPECTOGRAM_SAMPLERATE_HZ: 24000  # -1 indicates undefined otherwise: 24000 | 48000
     TEST_INPUT_PATH: /data/input-files/testob/visxp_prep__testob.tar.gz
 INPUT:
-    S3_ENDPOINT_URL: https://s3.eu-west-1.amazonaws.com/
+    S3_ENDPOINT_URL: https://s3-host
     MODEL_CHECKPOINT_S3_URI: s3://beng-daan-visxp/model/checkpoint.tar
     MODEL_CONFIG_S3_URI: s3://beng-daan-visxp/model/model_config.yml
     DELETE_ON_COMPLETION: False
 OUTPUT:
     DELETE_ON_COMPLETION: True
     TRANSFER_ON_COMPLETION: True
-    S3_ENDPOINT_URL: https://s3.eu-west-1.amazonaws.com/
+    S3_ENDPOINT_URL: https://s3-host
     S3_BUCKET: beng-daan-visxp  # bucket reserved for 1 type of output
     S3_FOLDER_IN_BUCKET: assets  # folder within the bucket
 DANE_DEPENDENCIES:

--- a/feature_extraction.py
+++ b/feature_extraction.py
@@ -61,9 +61,11 @@ def run(
 
     # Step 4: Load spectograms + keyframes from file & preprocess
     dataset = VisXPData(
-        Path(input_file_path),
+        datapath=Path(input_file_path),
         model_config_file=os.path.join(model_base_mount, model_config_file),
         device=device,
+        expected_sample_rate=feature_extraction_input.expected_sample_rate,
+        check_spec_dim=False,
     )
 
     # Step 5: Load model from file

--- a/io_util.py
+++ b/io_util.py
@@ -255,6 +255,7 @@ def obtain_input_file(s3_uri: str) -> VisXPFeatureExtractionInput:
             f"Failed to download: {s3_uri}",
             source_id_from_s3_uri(s3_uri),  # source_id
             input_file_path,  # locally downloaded .tar.gz
+            cfg.VISXP_EXTRACT.EXPECTED_SPECTOGRAM_SAMPLERATE_HZ,
             provenance,
         )
     logger.error("Failed to download VISXP_PREP data from S3")

--- a/models.py
+++ b/models.py
@@ -48,6 +48,7 @@ class VisXPFeatureExtractionInput:
     message: str  # error/sucess message
     source_id: str = ""  # <program ID>__<carrier ID>
     input_file_path: str = ""  # where the visxp_prep.tar.gz was downloaded
+    expected_sample_rate: int = -1  # VISXP_EXTRACT.EXPECTED_SPECTOGRAM_SAMPLERATE_HZ
     provenance: Optional[Provenance] = None  # mostly: how long did it take to download
 
 

--- a/models.py
+++ b/models.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Optional, TypedDict
 
@@ -26,9 +26,10 @@ class Provenance:
     output_data: dict[str, str]
     parameters: Optional[dict] = None
     software_version: Optional[dict[str, str]] = None
-    steps: Optional[list["Provenance"]] = None  # a list of subactivity provenance items
+    steps: Optional[list["Provenance"]] = field(default_factory=list["Provenance"])
 
     def to_json(self):
+        processing_steps = self.steps if self.steps else []
         return {
             "activity_name": self.activity_name,
             "activity_description": self.activity_description,
@@ -38,7 +39,7 @@ class Provenance:
             "software_version": self.software_version,  # .to_json
             "input_data": self.input_data,  # .to_json
             "output_data": self.output_data,  # .to_json
-            "steps": [step.to_json for step in self.steps],
+            "steps": [step.to_json() for step in processing_steps],
         }
 
 

--- a/tests/unit/data_handling_test.py
+++ b/tests/unit/data_handling_test.py
@@ -5,9 +5,11 @@ import torch
 def test_batches():
     device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     dataset = VisXPData(
-        "data/input-files/test_source_id",
-        device=device,
+        datapath="data/input-files/test_source_id",
         model_config_file="model/model_config.yml",
+        device=device,
+        expected_sample_rate=-1,  # not specified in the test data
+        check_spec_dim=False,
     )
     for i, item in enumerate(dataset.batches(1)):
         index = int(item["timestamp"][0])

--- a/tests/unit/feature_extraction_test.py
+++ b/tests/unit/feature_extraction_test.py
@@ -19,6 +19,7 @@ def test_extract_features():
             f"Thank you for unit testing: let's process {UNIT_TEST_INPUT_PATH}",
             UNIT_TEST_SOURCE_ID,
             UNIT_TEST_INPUT_PATH,
+            -1,
             None,  # no provenance needed in test
         ),
         model_base_mount="model",

--- a/worker.py
+++ b/worker.py
@@ -47,6 +47,7 @@ def process_configured_input_file() -> bool:
             f"Thank you for running us: let's test {cfg.VISXP_EXTRACT.TEST_INPUT_PATH}",
             get_source_id_from_tar(cfg.VISXP_EXTRACT.TEST_INPUT_PATH),
             cfg.VISXP_EXTRACT.TEST_INPUT_PATH,
+            cfg.VISXP_EXTRACT.EXPECTED_SPECTOGRAM_SAMPLERATE_HZ,  # make sure this matches VISXP_PREP config
             None,  # no provenance needed in test
         )
 


### PR DESCRIPTION
this fixes the bug that happens in case more than one samplerate is available in the spectogram dir (created by the "VISXP_PREP worker")


Also fix a bug that was copied over from an older version of the 1st worker