### PR TITLE
20 proper indexing of input

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -32,7 +32,6 @@ VISXP_EXTRACT:
     MODEL_BASE_MOUNT: /model
     MODEL_CHECKPOINT_FILE: checkpoint.tar  # should be in MODEL_BASE_MOUNT
     MODEL_CONFIG_FILE: model_config.yml  # should be in MODEL_BASE_MOUNT
-    EXPECTED_SPECTOGRAM_SAMPLERATE_HZ: 24000  # -1 indicates undefined otherwise: 24000 | 48000
     TEST_INPUT_PATH: /data/input-files/testob/visxp_prep__testob.tar.gz
 INPUT:
     S3_ENDPOINT_URL: https://s3-host

--- a/data_handling.py
+++ b/data_handling.py
@@ -26,18 +26,20 @@ class VisXPData(Dataset):
     ):
         if type(datapath) is not Path:
             datapath = Path(datapath)
+
+        self.set_config(model_config_file=model_config_file)
+
         # Sorting not really necessary, but is a (poor) way of making sure specs and frames are aligned..
         self.frame_paths = sorted(list(datapath.glob(f"{KEYFRAME_INPUT_DIR}/*.jpg")))
 
         # first determine if/which spectogram files to select
-        spectogram_suffix = (
-            "" if expected_sample_rate == -1 else f"_{expected_sample_rate}"
-        )
+        spectogram_suffix = f"_{self.dim_a}"
+        
         self.spec_paths = sorted(
             list(datapath.glob(f"{SPECTOGRAM_INPUT_DIR}/*{spectogram_suffix}.npz"))
         )  # one samplerate is used
         self.device = device
-        self.set_config(model_config_file=model_config_file)
+        
         self.list_of_shots = self.ListOfShots(datapath)
 
         # NOTE use the keyframe list to determine __len__, since there can be

--- a/data_handling.py
+++ b/data_handling.py
@@ -32,9 +32,9 @@ class VisXPData(Dataset):
 
         self.paths: DefaultDict[int, dict] = defaultdict(dict)
         for p in datapath.glob(f"{KEYFRAME_INPUT_DIR}/*.jpg"):
-            self.paths[int(p.stem)].update({'frame': p})
+            self.paths[int(p.stem)].update({"frame": p})
         for p in datapath.glob(f"{SPECTOGRAM_INPUT_DIR}/*_{self.framerate}.npz"):
-            self.paths[int(p.stem.split('_')[0])].update({'spec': p})
+            self.paths[int(p.stem.split("_")[0])].update({"spec": p})
         self.timestamps = list(self.paths.keys())
         self.device = device
         self.list_of_shots = self.ListOfShots(datapath)
@@ -75,20 +75,22 @@ class VisXPData(Dataset):
 
     def __get_spec__(self, timestamp: int, transform=True):
         try:
-            data = np.load(str(self.paths[timestamp]['spec']), allow_pickle=True)
+            data = np.load(str(self.paths[timestamp]["spec"]), allow_pickle=True)
             audio = data["arr_0"].item()["audio"]
             audio = torch.tensor(audio, device=self.device)
             if transform:
                 audio = self.audio_transform(audio)
         except KeyError:
-            logger.info(f"No spectogram exists for timestamp {timestamp}"
-                        f" at samplerate {self.framerate}.")
+            logger.info(
+                f"No spectogram exists for timestamp {timestamp}"
+                f" at samplerate {self.framerate}."
+            )
             audio = torch.zeros(size=self.dim_a)
         return audio
 
     def __get_keyframe__(self, timestamp: int):
         try:
-            image_file_path = str(self.paths[timestamp]['frame'])
+            image_file_path = str(self.paths[timestamp]["frame"])
             frame = torchvision.io.read_image(image_file_path).to(self.device)
             frame = self.visual_transform(frame / 255.0)
         except KeyError:

--- a/data_handling.py
+++ b/data_handling.py
@@ -36,8 +36,6 @@ class VisXPData(Dataset):
         for p in datapath.glob(f"{SPECTOGRAM_INPUT_DIR}/*_{self.framerate}.npz"):
             self.paths[int(p.stem.split('_')[0])].update({'spec': p})
         self.timestamps = list(self.paths.keys())
-        import pdb
-        pdb.set_trace()
         self.device = device
         self.list_of_shots = self.ListOfShots(datapath)
 

--- a/data_handling.py
+++ b/data_handling.py
@@ -22,7 +22,6 @@ class VisXPData(Dataset):
         datapath: Path,
         model_config_file: str,
         device: torch.device,
-        expected_sample_rate=-1,  # 24000 | 48000
         check_spec_dim=False,
     ):
         if type(datapath) is not Path:

--- a/feature_extraction.py
+++ b/feature_extraction.py
@@ -65,7 +65,7 @@ def run(
     dataset = VisXPData(
         datapath=Path(input_file_path),
         model_config_file=os.path.join(model_base_mount, model_config_file),
-        device=device
+        device=device,
     )
 
     # Step 5: Load model from file

--- a/feature_extraction.py
+++ b/feature_extraction.py
@@ -18,6 +18,8 @@ def apply_model(batch, model, device):
     frames, spectograms = batch["video"], batch["audio"]
     timestamps = batch["timestamp"].to(device)
     shots = batch["shot_boundaries"].to(device)
+    # TODO: mask/disregard all zero frames/spectograms
+    # (for the, now theoretical, case of only audio OR video existing)
     with torch.no_grad():  # Forward pass to get the features
         audio_feat = model.audio_model(spectograms)
         visual_feat = model.video_model(frames)

--- a/feature_extraction.py
+++ b/feature_extraction.py
@@ -65,9 +65,7 @@ def run(
     dataset = VisXPData(
         datapath=Path(input_file_path),
         model_config_file=os.path.join(model_base_mount, model_config_file),
-        device=device,
-        expected_sample_rate=feature_extraction_input.expected_sample_rate,
-        check_spec_dim=False,
+        device=device
     )
 
     # Step 5: Load model from file

--- a/io_util.py
+++ b/io_util.py
@@ -255,7 +255,6 @@ def obtain_input_file(s3_uri: str) -> VisXPFeatureExtractionInput:
             f"Failed to download: {s3_uri}",
             source_id_from_s3_uri(s3_uri),  # source_id
             input_file_path,  # locally downloaded .tar.gz
-            cfg.VISXP_EXTRACT.EXPECTED_SPECTOGRAM_SAMPLERATE_HZ,
             provenance,
         )
     logger.error("Failed to download VISXP_PREP data from S3")

--- a/models.py
+++ b/models.py
@@ -49,7 +49,6 @@ class VisXPFeatureExtractionInput:
     message: str  # error/sucess message
     source_id: str = ""  # <program ID>__<carrier ID>
     input_file_path: str = ""  # where the visxp_prep.tar.gz was downloaded
-    expected_sample_rate: int = -1  # VISXP_EXTRACT.EXPECTED_SPECTOGRAM_SAMPLERATE_HZ
     provenance: Optional[Provenance] = None  # mostly: how long did it take to download
 
 

--- a/tests/unit/data_handling_test.py
+++ b/tests/unit/data_handling_test.py
@@ -8,7 +8,6 @@ def test_batches():
         datapath="data/input-files/test_source_id",
         model_config_file="model/model_config.yml",
         device=device,
-        expected_sample_rate=-1,  # not specified in the test data
         check_spec_dim=False,
     )
     for i, item in enumerate(dataset.batches(1)):

--- a/tests/unit/feature_extraction_test.py
+++ b/tests/unit/feature_extraction_test.py
@@ -19,7 +19,6 @@ def test_extract_features():
             f"Thank you for unit testing: let's process {UNIT_TEST_INPUT_PATH}",
             UNIT_TEST_SOURCE_ID,
             UNIT_TEST_INPUT_PATH,
-            -1,
             None,  # no provenance needed in test
         ),
         model_base_mount="model",

--- a/worker.py
+++ b/worker.py
@@ -42,10 +42,15 @@ def process_configured_input_file() -> bool:
     if validate_s3_uri(cfg.VISXP_EXTRACT.TEST_INPUT_PATH):
         feature_extraction_input = obtain_input_file(cfg.VISXP_EXTRACT.TEST_INPUT_PATH)
     else:
+        if cfg.VISXP_EXTRACT.TEST_INPUT_PATH.find(".tar.gz") != -1:
+            source_id = get_source_id_from_tar(cfg.VISXP_EXTRACT.TEST_INPUT_PATH)
+        else:
+            source_id = cfg.VISXP_EXTRACT.TEST_INPUT_PATH.split('/')[-1]
+
         feature_extraction_input = VisXPFeatureExtractionInput(
             200,
             f"Thank you for running us: let's test {cfg.VISXP_EXTRACT.TEST_INPUT_PATH}",
-            get_source_id_from_tar(cfg.VISXP_EXTRACT.TEST_INPUT_PATH),
+            source_id,
             cfg.VISXP_EXTRACT.TEST_INPUT_PATH,
             None,  # no provenance needed in test
         )

--- a/worker.py
+++ b/worker.py
@@ -47,7 +47,6 @@ def process_configured_input_file() -> bool:
             f"Thank you for running us: let's test {cfg.VISXP_EXTRACT.TEST_INPUT_PATH}",
             get_source_id_from_tar(cfg.VISXP_EXTRACT.TEST_INPUT_PATH),
             cfg.VISXP_EXTRACT.TEST_INPUT_PATH,
-            cfg.VISXP_EXTRACT.EXPECTED_SPECTOGRAM_SAMPLERATE_HZ,  # make sure this matches VISXP_PREP config
             None,  # no provenance needed in test
         )
 

--- a/worker.py
+++ b/worker.py
@@ -45,7 +45,7 @@ def process_configured_input_file() -> bool:
         if cfg.VISXP_EXTRACT.TEST_INPUT_PATH.find(".tar.gz") != -1:
             source_id = get_source_id_from_tar(cfg.VISXP_EXTRACT.TEST_INPUT_PATH)
         else:
-            source_id = cfg.VISXP_EXTRACT.TEST_INPUT_PATH.split('/')[-1]
+            source_id = cfg.VISXP_EXTRACT.TEST_INPUT_PATH.split("/")[-1]
 
         feature_extraction_input = VisXPFeatureExtractionInput(
             200,


### PR DESCRIPTION
Store filepaths for spectograms and frames in a dict, and keep a list of the available timestamps. 
If (for now theoretical scenario) either frame or spectogram does not exist, the dataloader will return an all zeroes tensor in those cases. 
TODO: keep it all zeroes after applying the model, to signal that this feature vector is meaningless. This is not trivial, and since it is a theoretical scenario for now, I placed this out of scope. 

Have done some manual checking, no unit tests (yet). 

Also removed spectogram dimensionality from general config: this is obtained from model config. 