### PR TITLE
29 convert output to non torch

### DIFF
--- a/feature_extraction.py
+++ b/feature_extraction.py
@@ -9,6 +9,8 @@ from data_handling import VisXPData
 from io_util import untar_input_file
 from models import VisXPFeatureExtractionInput, Provenance
 from nn_models import load_model_from_file
+import numpy as np
+
 
 logger = logging.getLogger(__name__)
 
@@ -115,6 +117,7 @@ def _save_features_to_file(features: torch.Tensor, output_file_path: str) -> boo
         if not os.path.isdir(parent_dir):
             logger.info("Parent dir, did not exist, creating it now")
             os.makedirs(parent_dir)
+        np.save(output_file_path, np.array(features))
         return True
     except Exception:
         logger.exception("Failed to save features to file")

--- a/feature_extraction.py
+++ b/feature_extraction.py
@@ -9,7 +9,7 @@ from data_handling import VisXPData
 from io_util import untar_input_file
 from models import VisXPFeatureExtractionInput, Provenance
 from nn_models import load_model_from_file
-
+import numpy as np
 
 logger = logging.getLogger(__name__)
 
@@ -116,9 +116,7 @@ def _save_features_to_file(features: torch.Tensor, output_file_path: str) -> boo
         if not os.path.isdir(parent_dir):
             logger.info("Parent dir, did not exist, creating it now")
             os.makedirs(parent_dir)
-        with open(output_file_path, "wb") as f:
-            torch.save(obj=features, f=f)
-            return True
+        np.save(output_file_path, np.array(features))
     except Exception:
         logger.exception("Failed to save features to file")
     return False

--- a/feature_extraction.py
+++ b/feature_extraction.py
@@ -116,7 +116,7 @@ def _save_features_to_file(features: torch.Tensor, output_file_path: str) -> boo
         if not os.path.isdir(parent_dir):
             logger.info("Parent dir, did not exist, creating it now")
             os.makedirs(parent_dir)
-        np.save(output_file_path, np.array(features))
+        return True
     except Exception:
         logger.exception("Failed to save features to file")
-    return False
+        return False

--- a/feature_extraction.py
+++ b/feature_extraction.py
@@ -9,7 +9,6 @@ from data_handling import VisXPData
 from io_util import untar_input_file
 from models import VisXPFeatureExtractionInput, Provenance
 from nn_models import load_model_from_file
-import numpy as np
 
 logger = logging.getLogger(__name__)
 

--- a/io_util.py
+++ b/io_util.py
@@ -86,7 +86,7 @@ def get_output_file_name(source_id: str, output_type: OutputType) -> str:
     output_file_name = ""
     match output_type:
         case OutputType.FEATURES:
-            output_file_name = f"{OUTPUT_FILE_BASE_NAME}__{source_id}.pt"
+            output_file_name = f"{OUTPUT_FILE_BASE_NAME}__{source_id}.npy"
         case OutputType.PROVENANCE:
             output_file_name = "provenance.json"
     return output_file_name

--- a/tests/unit/feature_extraction_test.py
+++ b/tests/unit/feature_extraction_test.py
@@ -4,7 +4,7 @@ import torch
 import feature_extraction
 from io_util import get_output_file_path
 from models import OutputType, VisXPFeatureExtractionInput
-
+import numpy as np
 
 UNIT_TEST_SOURCE_ID = "test_source_id"
 UNIT_TEST_INPUT_PATH = f"./data/input-files/{UNIT_TEST_SOURCE_ID}"
@@ -26,8 +26,8 @@ def test_extract_features():
         model_config_file="model_config.yml",
         output_file_path=feature_file,
     )
-    with open(feature_file, "rb") as f:
-        features = torch.load(f)
+
+    features = torch.Tensor(np.load(feature_file))
     with open("./data/demo_concat_feat.pt", "rb") as f:
         example_features = torch.load(f)
 


### PR DESCRIPTION
Convert resulting torch tensor (with features) to numpy array. Store the array using numpy.save to a .npy file. 

NB: the reason for this, is that we don't require torch (which is quite heavy) for further processing (e.g. Exporting). 
We did however already process a bunch of files. 
We should consider scripting the torch to numpy conversion for that batch, to avoid processing everything again only for this conversion. 